### PR TITLE
Check /sys/class/remoteproc/ exists before iterating in it.

### DIFF
--- a/src/ui/panel/pru/pru_impl.cpp
+++ b/src/ui/panel/pru/pru_impl.cpp
@@ -66,6 +66,8 @@ class PRUPanel : public PanelBase {
 
  private:
   void BuildUI() {
+    if (!std::filesystem::exists("/sys/class/remoteproc/"))
+      return;
     Component vertical_list = Container::Vertical({});
     for (const auto& it :
          std::filesystem::directory_iterator("/sys/class/remoteproc/")) {
@@ -91,18 +93,18 @@ class PRUPanel : public PanelBase {
       info_list.push_back(text(child->info()));
     }
 
-    return window(text(" PRUSS  "), hbox({
-                                        vbox(std::move(name_list)),
-                                        separator(),
-                                        vbox(std::move(firmware_list)),
-                                        separator(),
-                                        vbox(std::move(state_list)),
-                                        separator(),
-                                        vbox(std::move(action_list)) | flex,
-                                        separator(),
-                                        vbox(std::move(info_list)) | flex,
-                                    }) | frame |
-                                        flex);
+    return window(text(" PRUS(s)  "), hbox({
+                                          vbox(std::move(name_list)),
+                                          separator(),
+                                          vbox(std::move(firmware_list)),
+                                          separator(),
+                                          vbox(std::move(state_list)),
+                                          separator(),
+                                          vbox(std::move(action_list)) | flex,
+                                          separator(),
+                                          vbox(std::move(info_list)) | flex,
+                                      }) | frame |
+                                          flex);
   }
 
   std::vector<std::shared_ptr<Pru>> children_;
@@ -110,6 +112,7 @@ class PRUPanel : public PanelBase {
 
 namespace panel {
 Panel PRU() {
+
   return Make<PRUPanel>();
 }
 


### PR DESCRIPTION
Check /sys/class/remoteproc/ exists before iterating in it.

If we don't, this triggers the exception:
```
terminate called after throwing an instance of
'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: directory iterator cannot open directory:
  No such file or directory [/sys/class/remoteproc/]
```